### PR TITLE
CSUB-1160: DEBUG failing tests without updating Ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+IGNORE ME
+
 > NOTE: We have recently made significant changes to our repository structure. In order to streamline our development
 process and foster better contributions, we have merged three separate repositories Cumulus, Substrate and Polkadot into
 this repository. Read more about the changes [


### PR DESCRIPTION
For some reason just before the test suite finishes it fails:
https://github.com/gluwa/polkadot-sdk/actions/runs/9384565936/job/25878129324?pr=3

I haven't seen this previously and atm the suspicion is that is happens b/c of the Ubuntu upgrade.  Use this PR as a cross-reference data point. 